### PR TITLE
removed import from six.moves

### DIFF
--- a/pyhsmm/util/general.py
+++ b/pyhsmm/util/general.py
@@ -6,7 +6,7 @@ from numpy.lib.stride_tricks import as_strided as ast
 import scipy.linalg
 import copy, collections, os, shutil, hashlib
 from contextlib import closing
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 from itertools import chain, count
 from functools import reduce
 


### PR DESCRIPTION
for compatibility with python 3.9. Tested on M1 Mac.